### PR TITLE
Ensure asset info page has 5mld title

### DIFF
--- a/app/views/asset/AssetInterruptPageView.scala.html
+++ b/app/views/asset/AssetInterruptPageView.scala.html
@@ -25,21 +25,25 @@
 @(draftId: String, is5mldEnabled: Boolean)(implicit request: Request[_], messages: Messages)
 
 @main_template(
-    title = messages("assetInterruptPage.title")
+    title = if(is5mldEnabled) {messages("assetInterruptPage.5mld.title")} else {messages("assetInterruptPage.title")}
 ) {
 
     @formHelper(action = AssetInterruptPageController.onSubmit(draftId), 'autoComplete -> "off") {
 
         @components.back_link()
 
-        <span class="govuk-caption-xl">Assets</span>
-        @components.heading("assetInterruptPage.heading", headingSize = "heading-large govuk-fieldset__heading")
+        @if(is5mldEnabled){
+            @components.heading_with_caption("assetInterruptPage.5mld")
+        } else {
+            @components.heading_with_caption("assetInterruptPage")
+        }
 
         <h2>@messages("assetInterruptPage.subheading1")</h2>
         <p>@messages("assetInterruptPage.paragraph1")</p>
 
         <h2>@messages("assetInterruptPage.subheading2")</h2>
         <p>@messages("assetInterruptPage.paragraph2")</p>
+
         @components.bullet_list(
             "assetInterruptPage",
             List(

--- a/app/views/components/heading_with_caption.scala.html
+++ b/app/views/components/heading_with_caption.scala.html
@@ -1,4 +1,4 @@
-/*
+@*
  * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,30 +12,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *@
 
-package views
+@(messagePrefix: String, optionalParam: Option[String] = None, headingParam: Option[String] = None)(implicit messages: Messages)
 
-import views.behaviours.ViewBehaviours
-import views.html.SessionExpiredView
-
-class SessionExpiredViewSpec extends ViewBehaviours {
-
-  "Session Expired view" must {
-
-    val application = applicationBuilder().build()
-
-    val view = application.injector.instanceOf[SessionExpiredView]
-
-    val applyView = view.apply()(fakeRequest, messages)
-
-    behave like normalPage(applyView, "session_expired")
-
-    behave like pageWithGuidance(applyView,
-      messageKeyPrefix = "session_expired",
-      expectedGuidanceKeys =
-        "guidance",
-        "guidance.2",
-    )
-  }
-}
+<header class="hmrc-page-heading">
+ <h1 class="govuk-heading-xl">
+  @components.sub_heading(messagePrefix, headingParam.getOrElse(""))
+  @messages(s"$messagePrefix.heading", optionalParam.getOrElse(""))
+ </h1>
+</header>

--- a/app/views/components/sub_heading.scala.html
+++ b/app/views/components/sub_heading.scala.html
@@ -1,4 +1,4 @@
-/*
+@*
  * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,30 +12,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *@
 
-package views
+@(messagePrefix: String, param: String, hiddenText: Boolean = true)(implicit messages: Messages)
 
-import views.behaviours.ViewBehaviours
-import views.html.SessionExpiredView
-
-class SessionExpiredViewSpec extends ViewBehaviours {
-
-  "Session Expired view" must {
-
-    val application = applicationBuilder().build()
-
-    val view = application.injector.instanceOf[SessionExpiredView]
-
-    val applyView = view.apply()(fakeRequest, messages)
-
-    behave like normalPage(applyView, "session_expired")
-
-    behave like pageWithGuidance(applyView,
-      messageKeyPrefix = "session_expired",
-      expectedGuidanceKeys =
-        "guidance",
-        "guidance.2",
-    )
-  }
-}
+<span class="govuk-caption-xl">
+ @if(hiddenText){
+  <span class="visually-hidden">@messages(s"$messagePrefix.caption.hidden") </span>
+ }
+ @messages(s"$messagePrefix.caption", param)
+</span>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -144,6 +144,13 @@ assets.removeYesNo.error.required = Select yes if you want to remove the asset
 
 assetInterruptPage.title = Information you’ll need to provide
 assetInterruptPage.heading = Information you’ll need to provide
+assetInterruptPage.caption = Assets
+assetInterruptPage.caption.hidden = This section is
+
+assetInterruptPage.5mld.title = Information you need to know to add assets
+assetInterruptPage.5mld.heading = Information you need to know to add assets
+assetInterruptPage.5mld.caption = Assets
+assetInterruptPage.5mld.caption.hidden = This section is
 
 assetInterruptPage.subheading1 = Money
 assetInterruptPage.paragraph1 = Tell us the total amount of money in the trust. If more than one amount has been added to the trust, add them together.

--- a/test/views/ViewSpecBase.scala
+++ b/test/views/ViewSpecBase.scala
@@ -51,7 +51,37 @@ trait ViewSpecBase extends SpecBase {
   def assertPageTitleEqualsMessage(doc: Document, expectedMessageKey: String, args: Any*): Assertion = {
     val headers = doc.getElementsByTag("h1")
     headers.size mustBe 1
-    headers.first.text.replaceAll("\u00a0", " ") mustBe messages(expectedMessageKey, args:_*).replaceAll("&nbsp;", " ")
+
+    val expected = messages(s"$expectedMessageKey.heading", args:_*)
+      .replaceAll("&nbsp;", " ")
+
+    val actual = headers
+      .first
+      .text
+      .replaceAll("\u00a0", " ")
+
+    actual mustBe expected
+  }
+
+  def assertPageTitleWithCaptionEqualsMessage(doc: Document,
+                                              expectedMessageKey: String,
+                                              args: Any*): Assertion = {
+    val headers = doc.getElementsByTag("h1")
+    headers.size mustBe 1
+
+    val expectedCaption = s"${messages(s"$expectedMessageKey.caption.hidden")} ${messages(s"$expectedMessageKey.caption")}"
+
+    val expectedHeading = messages(s"$expectedMessageKey.heading", args:_*)
+
+    val expected = s"$expectedCaption $expectedHeading"
+      .replaceAll("&nbsp;", " ")
+
+    val actual = headers
+      .first
+      .text
+      .replaceAll("\u00a0", " ")
+
+    actual mustBe expected
   }
 
   def assertContainsText(doc:Document, text: String): Assertion = assert(doc.toString.contains(text), "\n\ntext " + text + " was not rendered on the page.\n")

--- a/test/views/asset/AssetInterruptPageViewSpec.scala
+++ b/test/views/asset/AssetInterruptPageViewSpec.scala
@@ -29,9 +29,13 @@ class AssetInterruptPageViewSpec extends ViewBehaviours {
 
       val applyView = view.apply(fakeDraftId, is5mldEnabled = false)(fakeRequest, messages)
 
-      behave like normalPage(applyView, "assetInterruptPage",
-        "title",
-        "subheading1",
+      behave like normalPage(applyView, "assetInterruptPage", ignoreTitle = true)
+
+      behave like pageWithTitleAndCaption(applyView, "assetInterruptPage")
+
+      behave like pageWithGuidance(applyView,
+        messageKeyPrefix = "assetInterruptPage",
+        expectedGuidanceKeys = "subheading1",
         "paragraph1",
         "subheading2",
         "paragraph2",
@@ -67,9 +71,13 @@ class AssetInterruptPageViewSpec extends ViewBehaviours {
 
       val applyView = view.apply(fakeDraftId, is5mldEnabled = true)(fakeRequest, messages)
 
-      behave like normalPage(applyView, "assetInterruptPage",
-        "title",
-        "subheading1",
+      behave like normalPage(applyView, "assetInterruptPage.5mld", ignoreTitle = true)
+
+      behave like pageWithTitleAndCaption(applyView, "assetInterruptPage.5mld")
+
+      behave like pageWithGuidance(applyView,
+        messageKeyPrefix = "assetInterruptPage",
+        expectedGuidanceKeys = "subheading1",
         "paragraph1",
         "subheading2",
         "paragraph2",
@@ -90,12 +98,6 @@ class AssetInterruptPageViewSpec extends ViewBehaviours {
         "bullet8",
         "bullet9",
         "bullet10",
-        "subheading7",
-        "paragraph10",
-        "bullet11",
-        "bullet12",
-        "bullet13",
-        "bullet14",
         "subheading5",
         "paragraph8",
         "subheading6",

--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -23,7 +23,7 @@ trait ViewBehaviours extends ViewSpecBase {
 
   def normalPage(view: HtmlFormat.Appendable,
                  messageKeyPrefix: String,
-                 expectedGuidanceKeys: String*): Unit = {
+                 ignoreTitle : Boolean = false): Unit = {
 
     "behave like a normal page" when {
 
@@ -43,16 +43,8 @@ trait ViewBehaviours extends ViewSpecBase {
           assertEqualsMessage(doc, "title", s"$messageKeyPrefix.title")
         }
 
-        "display the correct page title" in {
-
-          val doc = asDocument(view)
-          assertPageTitleEqualsMessage(doc, s"$messageKeyPrefix.heading")
-        }
-
-        "display the correct guidance" in {
-
-          val doc = asDocument(view)
-          for (key <- expectedGuidanceKeys) assertContainsText(doc, messages(s"$messageKeyPrefix.$key"))
+        if (!ignoreTitle) {
+          pageWithTitle(view, messageKeyPrefix)
         }
 
         "display language toggles" in {
@@ -61,6 +53,30 @@ trait ViewBehaviours extends ViewSpecBase {
           assertRenderedById(doc, "cymraeg-switch")
         }
       }
+    }
+  }
+
+  def pageWithGuidance(view: HtmlFormat.Appendable, messageKeyPrefix: String, expectedGuidanceKeys: String*): Unit = {
+    "display the correct guidance" in {
+
+      val doc = asDocument(view)
+      for (key <- expectedGuidanceKeys) assertContainsText(doc, messages(s"$messageKeyPrefix.$key"))
+    }
+  }
+
+  def pageWithTitle(view: HtmlFormat.Appendable, messageKeyPrefix: String, args: Any*) : Unit = {
+    "display the correct page title" in {
+
+      val doc = asDocument(view)
+      assertPageTitleEqualsMessage(doc, s"$messageKeyPrefix", args: _*)
+    }
+  }
+
+  def pageWithTitleAndCaption(view: HtmlFormat.Appendable, messageKeyPrefix: String) : Unit = {
+    "display the correct page title with caption" in {
+
+      val doc = asDocument(view)
+      assertPageTitleWithCaptionEqualsMessage(doc, s"$messageKeyPrefix")
     }
   }
 
@@ -87,11 +103,7 @@ trait ViewBehaviours extends ViewSpecBase {
           assertEqualsMessage(doc, "title", s"$messageKeyPrefix.title", messageKeyParam)
         }
 
-        "display the correct page title" in {
-
-          val doc = asDocument(view)
-          assertPageTitleEqualsMessage(doc, s"$messageKeyPrefix.heading", messageKeyParam)
-        }
+        pageWithTitle(view, messageKeyPrefix, messageKeyParam)
 
         "display the correct guidance" in {
 


### PR DESCRIPTION
- Add in hidden 'This section is' content for screenreaders