### PR TITLE
DDCE-5067: Update to stop form submission with smart apostrophes

### DIFF
--- a/app/config/annotations/Asset.java
+++ b/app/config/annotations/Asset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/Business.java
+++ b/app/config/annotations/Business.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/Money.java
+++ b/app/config/annotations/Money.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/NonEeaBusiness.java
+++ b/app/config/annotations/NonEeaBusiness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/Other.java
+++ b/app/config/annotations/Other.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/Partnership.java
+++ b/app/config/annotations/Partnership.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/PropertyOrLand.java
+++ b/app/config/annotations/PropertyOrLand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/Shares.java
+++ b/app/config/annotations/Shares.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/InternationalAddressFormProvider.scala
+++ b/app/forms/InternationalAddressFormProvider.scala
@@ -50,8 +50,7 @@ class InternationalAddressFormProvider @Inject() extends Mappings {
           ),
       "line3"   ->
         optional(
-          Forms.text
-            .transform(trimWhitespace, identity[String])
+          text()
             .verifying(
               firstError(
                 maxLength(maxLength, "internationalAddress.error.line3.length"),

--- a/app/forms/UKAddressFormProvider.scala
+++ b/app/forms/UKAddressFormProvider.scala
@@ -50,8 +50,7 @@ class UKAddressFormProvider @Inject() extends Mappings {
           ),
       "line3"    ->
         optional(
-          Forms.text
-            .transform(trimWhitespace, identity[String])
+          text()
             .verifying(
               firstError(
                 maxLength(maxLength, "ukAddress.error.line3.length"),
@@ -61,8 +60,7 @@ class UKAddressFormProvider @Inject() extends Mappings {
         ).transform(emptyToNone, identity[Option[String]]),
       "line4"    ->
         optional(
-          Forms.text
-            .transform(trimWhitespace, identity[String])
+          text()
             .verifying(
               firstError(
                 maxLength(maxLength, "ukAddress.error.line4.length"),

--- a/app/forms/mappings/Formatters.scala
+++ b/app/forms/mappings/Formatters.scala
@@ -30,7 +30,7 @@ trait Formatters {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], String] =
       data.get(key) match {
         case None | Some("") => Left(Seq(FormError(key, errorKey)))
-        case Some(s)         => Right(s)
+        case Some(s)         => Right(s.trim.replace("‘", "'").replace("’", "'"))
       }
 
     override def unbind(key: String, value: String): Map[String, String] =

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,10 +2,10 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.22.0"
+  val bootstrapVersion = "7.23.0"
 
   private val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "play-frontend-hmrc"            % "7.23.0-play-28",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"            % "7.29.0-play-28",
     "uk.gov.hmrc" %% "play-conditional-form-mapping" % "1.13.0-play-28",
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28"    % bootstrapVersion
   )
@@ -14,9 +14,9 @@ object AppDependencies {
     "uk.gov.hmrc"         %% "bootstrap-test-play-28"  % bootstrapVersion,
     "org.scalatest"       %% "scalatest"               % "3.2.17",
     "org.scalatestplus"   %% "scalacheck-1-17"         % "3.2.17.0",
-    "org.jsoup"            % "jsoup"                   % "1.16.1",
-    "org.mockito"         %% "mockito-scala-scalatest" % "1.17.27",
-    "org.wiremock"         % "wiremock-standalone"     % "3.2.0",
+    "org.jsoup"            % "jsoup"                   % "1.17.2",
+    "org.mockito"         %% "mockito-scala-scalatest" % "1.17.30",
+    "org.wiremock"         % "wiremock-standalone"     % "3.3.1",
     "wolfendale"          %% "scalacheck-gen-regexp"   % "0.1.2",
     "com.vladsch.flexmark" % "flexmark-all"            % "0.64.8"
   ).map(_ % Test)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 // Try to remove when sbt 1.8.0+ and scoverage is 2.0.7+
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
-addSbtPlugin("uk.gov.hmrc"         % "sbt-auto-build"     % "3.14.0")
+addSbtPlugin("uk.gov.hmrc"         % "sbt-auto-build"     % "3.20.0")
 addSbtPlugin("uk.gov.hmrc"         % "sbt-distributables" % "2.2.0")
 addSbtPlugin("com.typesafe.play"   % "sbt-plugin"         % "2.8.20")
 addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle"     % "1.5.1")

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -53,6 +53,11 @@ class MappingsSpec extends AnyWordSpec with Matchers with OptionValues with Mapp
       result.get mustEqual "foobar"
     }
 
+    "filter out smart apostrophes on binding" in {
+      val boundValue = testForm bind Map("value" -> "We’re ‘aving fish ‘n’ chips for tea")
+      boundValue.get mustEqual "We're 'aving fish 'n' chips for tea"
+    }
+
     "not bind an empty string" in {
       val result = testForm.bind(Map("value" -> ""))
       result.errors must contain(FormError("value", "error.required"))


### PR DESCRIPTION
Screen shots showing evidence of smart apostrophes being replaced: 

![Screenshot 2024-02-02 at 14 49 51](https://github.com/hmrc/register-trust-asset-frontend/assets/125281117/18c5d2f6-8b5f-416e-a7b7-09b957aef17b)

![Screenshot 2024-02-02 at 14 50 09](https://github.com/hmrc/register-trust-asset-frontend/assets/125281117/63f4b0db-472a-42dd-b914-f853a4bc2293)

![Screenshot 2024-02-02 at 14 50 45](https://github.com/hmrc/register-trust-asset-frontend/assets/125281117/18d7106b-e8de-477c-99d0-f3b25414276a)

![Screenshot 2024-02-02 at 14 51 08](https://github.com/hmrc/register-trust-asset-frontend/assets/125281117/2ef478df-8850-49be-a78e-e9a30e95bc2b)
